### PR TITLE
Option to select a custom configuration when doing manage.py configure_routers. 

### DIFF
--- a/peering/management/commands/configure_routers.py
+++ b/peering/management/commands/configure_routers.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
             "-c",
             "--config",
             type=str,
-            help="Override default config to use for config generation/deployment. Give the name of the config template",
+            help="Override default configuration to use for config generation/deployment. Give the name of the configuration.",
         )
 
     def process(

--- a/peering/management/commands/configure_routers.py
+++ b/peering/management/commands/configure_routers.py
@@ -1,8 +1,7 @@
 from django.core.management.base import BaseCommand
 
-from devices.models import Configuration
-from django.shortcuts import get_object_or_404
 from core.models import Job
+from devices.models import Configuration
 from peering.jobs import set_napalm_configuration
 from peering.models import Router
 
@@ -34,15 +33,28 @@ class Command(BaseCommand):
             help="Override default config to use for config generation/deployment. Give the name of the config template",
         )
 
-    def process(self, router, quiet=False, as_task=False, no_commit_check=False, config_override=False):
-        
+    def process(
+        self,
+        router,
+        quiet=False,
+        as_task=False,
+        no_commit_check=False,
+        config_override=False,
+    ):
+
         # Override default configuration linked in the Router object
         if config_override:
             try:
-                router.configuration_template = Configuration.objects.get(name=config_override)
+                router.configuration_template = Configuration.objects.get(
+                    name=config_override
+                )
             except:
                 router.configuration_template = None
-                self.stdout.write(self.style.ERROR(f"Configuration object with name '{config_override}' not found"))
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"Configuration object with name '{config_override}' not found"
+                    )
+                )
 
         if not quiet:
             self.stdout.write(f"  - {router.hostname} ... ", ending="")
@@ -81,13 +93,13 @@ class Command(BaseCommand):
         )
         if options["limit"]:
             routers = routers.filter(hostname__in=options["limit"].split(","))
-        
-        
-        
+
         if not quiet:
             if options["config"]:
-                self.stdout.write(f"[*] Selecting configuration template '{options['config']}'")
-           
+                self.stdout.write(
+                    f"[*] Selecting configuration template '{options['config']}'"
+                )
+
             self.stdout.write("[*] Deploying configurations")
 
         for r in routers:


### PR DESCRIPTION
### Fixes:

Extra feature to be able to select a configuration template when doing configure_routers. This give you, for example, the option to add a cron job to only do a update of the prefix lists for IRR filtering and not doing a whole configuration update every cron cycle